### PR TITLE
fix issue when title contains strange char

### DIFF
--- a/pinyin/pinyin.py
+++ b/pinyin/pinyin.py
@@ -39,7 +39,11 @@ class PinYin(object):
         
         for char in string:
             key = '%X' % ord(char)
-            result.append(self.word_dict.get(key, char).split()[0][:-1].lower())
+            split_result = self.word_dict.get(key, char).split()
+            if len(split_result) > 0:
+                result.append(split_result[0][:-1].lower())
+            else:
+                result.append("")
 
         return result
 


### PR DESCRIPTION
解决在书签标题含有奇奇怪怪的字符时, 因为查不到拼音而解析出错的问题